### PR TITLE
Use HTTPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ $(PROXYFIED_COMMANDS):
 
 
 docker-rules.mk:
-	wget -qO - http://j.mp/scw-builder | bash
+	wget -qO - https://j.mp/scw-builder | bash


### PR DESCRIPTION
When piping the internet to a shell at least use HTTPS.